### PR TITLE
Defer the IS DISTINCT FROM check so that the trigger doesn't blow up when a column doesn't support an equality operator and `ignore_unchanged_values` is false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ![](https://github.com/nearform/temporal_tables/workflows/ci/badge.svg)
 
-_Version: 0.4.0_
+_Version: 0.4.1_
 
 This is an attempt to rewrite the postgresql [temporal_tables](https://github.com/arkhipov/temporal_tables) extension in PL/pgSQL, without the need for external c extension.
 
@@ -110,6 +110,8 @@ name  |     state     |                            sys_period
 
 <a name="ignore-unchanged-values"></a>
 ### Ignore updates without actual change
+
+**NOTE: This feature does not work for tables with columns with types that does not support equality operator (e.g. PostGIS types, JSON types, etc.).**
 
 By default this extension creates a record in the history table for every update that occurs in the versioned table, regardless of any change actually happening.
 

--- a/test/expected/non_equality_types.out
+++ b/test/expected/non_equality_types.out
@@ -1,0 +1,7 @@
+SET client_min_messages TO error
+CREATE TABLE non_equality_types (json json, sys_period tstzrange)
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON non_equality_types
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'non_equality_types', false)
+INSERT INTO non_equality_types VALUES ('{"a":1}'::json)
+UPDATE non_equality_types SET json = '{"a":2}'::json WHERE 1=1

--- a/test/expected/non_equality_types_unchanged_values.out
+++ b/test/expected/non_equality_types_unchanged_values.out
@@ -1,0 +1,9 @@
+SET client_min_messages TO error
+CREATE TABLE non_equality_types_unchanged_values (json json, sys_period tstzrange)
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON non_equality_types_unchanged_values
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'non_equality_types_unchanged_values', false, true)
+INSERT INTO non_equality_types_unchanged_values VALUES ('{"a":1}'::json)
+UPDATE non_equality_types_unchanged_values SET json = '{"a":2}'::json WHERE 1=1
+ERROR:  could not identify an equality operator for type json
+CONTEXT:  PL/pgSQL function versioning() line 39 at IF

--- a/test/runTest.sh
+++ b/test/runTest.sh
@@ -9,7 +9,8 @@ TESTS="
   no_history_table no_history_system_period no_system_period
   invalid_system_period_values invalid_system_period invalid_types
   versioning upper_case structure combinations
-  different_schema unchanged_values"
+  different_schema unchanged_values
+  non_equality_types non_equality_types_unchanged_values"
 
 for name in $TESTS; do
   echo ""

--- a/test/runTestNochecks.sh
+++ b/test/runTestNochecks.sh
@@ -5,7 +5,9 @@ psql temporal_tables_test -q -f versioning_function_nochecks.sql
 
 mkdir -p test/result
 
-TESTS="versioning upper_case structure combinations different_schema unchanged_values"
+TESTS="
+  versioning upper_case structure combinations different_schema unchanged_values
+  non_equality_types non_equality_types_unchanged_values"
 
 for name in $TESTS; do
   echo ""

--- a/test/sql/non_equality_types.sql
+++ b/test/sql/non_equality_types.sql
@@ -1,0 +1,11 @@
+SET client_min_messages TO error;
+
+CREATE TABLE non_equality_types (json json, sys_period tstzrange);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON non_equality_types
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'non_equality_types', false);
+
+INSERT INTO non_equality_types VALUES ('{"a":1}'::json);
+
+UPDATE non_equality_types SET json = '{"a":2}'::json WHERE 1=1;

--- a/test/sql/non_equality_types_unchanged_values.sql
+++ b/test/sql/non_equality_types_unchanged_values.sql
@@ -1,0 +1,11 @@
+SET client_min_messages TO error;
+
+CREATE TABLE non_equality_types_unchanged_values (json json, sys_period tstzrange);
+
+CREATE TRIGGER versioning_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON non_equality_types_unchanged_values
+FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'non_equality_types_unchanged_values', false, true);
+
+INSERT INTO non_equality_types_unchanged_values VALUES ('{"a":1}'::json);
+
+UPDATE non_equality_types_unchanged_values SET json = '{"a":2}'::json WHERE 1=1;

--- a/versioning_function.sql
+++ b/versioning_function.sql
@@ -14,7 +14,7 @@ DECLARE
   holder2 record;
   pg_version integer;
 BEGIN
-  -- version 0.4.0
+  -- version 0.4.1
 
   IF TG_WHEN != 'BEFORE' OR TG_LEVEL != 'ROW' THEN
     RAISE TRIGGER_PROTOCOL_VIOLATED USING
@@ -36,8 +36,10 @@ BEGIN
   history_table := TG_ARGV[1];
   ignore_unchanged_values := TG_ARGV[3];
 
-  IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND NEW IS NOT DISTINCT FROM OLD THEN
-    RETURN OLD;
+  IF ignore_unchanged_values AND TG_OP = 'UPDATE' THEN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+      RETURN OLD;
+    END IF;
   END IF;
 
   -- check if sys_period exists on original table

--- a/versioning_function_nochecks.sql
+++ b/versioning_function_nochecks.sql
@@ -11,14 +11,16 @@ DECLARE
   transaction_info txid_snapshot;
   existing_range tstzrange;
 BEGIN
-  -- version 0.4.0
+  -- version 0.4.1
 
   sys_period := TG_ARGV[0];
   history_table := TG_ARGV[1];
   ignore_unchanged_values := TG_ARGV[3];
 
-  IF ignore_unchanged_values AND TG_OP = 'UPDATE' AND NEW IS NOT DISTINCT FROM OLD THEN
-    RETURN OLD;
+  IF ignore_unchanged_values AND TG_OP = 'UPDATE' THEN
+    IF NEW IS NOT DISTINCT FROM OLD THEN
+      RETURN OLD;
+    END IF;
   END IF;
 
   IF TG_OP = 'UPDATE' OR TG_OP = 'DELETE' THEN


### PR DESCRIPTION
Defer the IS DISTINCT FROM check so that the trigger doesn't blow up when a column doesn't support an equality operator and `ignore_unchanged_values` is false.